### PR TITLE
Update student serial number range

### DIFF
--- a/supabase/migrations/20250719221820-ee9ff159-4f27-40d3-a482-0adea71f654d.sql
+++ b/supabase/migrations/20250719221820-ee9ff159-4f27-40d3-a482-0adea71f654d.sql
@@ -6,13 +6,18 @@ DECLARE
   counter INTEGER := 1;
 BEGIN
   LOOP
-    new_serial := LPAD(counter::TEXT, 4, '0');
+    new_serial := counter::TEXT;
     
     IF NOT EXISTS (SELECT 1 FROM public.students WHERE serial_number = new_serial) THEN
       RETURN new_serial;
     END IF;
     
     counter := counter + 1;
+    
+    -- Prevent infinite loop if we reach the maximum
+    IF counter > 99999 THEN
+      RAISE EXCEPTION 'No available serial numbers in range 1-99999';
+    END IF;
   END LOOP;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update student serial number generation to support the 1-99999 range and remove leading zero padding.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous database function generated 4-digit padded numbers (e.g., '0001'), which was inconsistent with the frontend and API's handling of serial numbers as integers within the 1-99999 range. This change aligns the database generation with the expected format and range.

---
<a href="https://cursor.com/background-agent?bcId=bc-13edad12-1e05-4ff7-9bff-eadf4d101bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13edad12-1e05-4ff7-9bff-eadf4d101bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>