### PR TITLE
Investigate bulk student upload payment and fees discrepancies

### DIFF
--- a/src/components/student/EnhancedBulkUploadModal.tsx
+++ b/src/components/student/EnhancedBulkUploadModal.tsx
@@ -225,7 +225,7 @@ export function EnhancedBulkUploadModal({ isOpen, onClose }: EnhancedBulkUploadM
         const registration = await studentRegistrationsApi.create({
           student_id: student.id,
           booking_id: targetBooking.id,
-          total_fees: studentData.payment,
+          total_fees: targetBooking.class_fees || 0, // Use booking's class fees, not individual payment
           notes: `Bulk upload from ${classData.sheetName}`
         });
 
@@ -235,6 +235,7 @@ export function EnhancedBulkUploadModal({ isOpen, onClose }: EnhancedBulkUploadM
           await paymentsApi.create({
             student_registration_id: registration.id,
             amount: studentData.payment,
+            payment_date: new Date().toISOString().split('T')[0],
             payment_method: 'cash',
             notes: `Bulk upload payment from ${classData.sheetName}`
           });

--- a/src/components/student/FastRegistrationModal.tsx
+++ b/src/components/student/FastRegistrationModal.tsx
@@ -151,6 +151,7 @@ export const FastRegistrationModal = ({ isOpen, onClose }: FastRegistrationModal
             return paymentsApi.create({
               student_registration_id: registration.id,
               amount: paidAmount,
+              payment_date: new Date().toISOString().split('T')[0],
               payment_method: 'cash',
               notes: 'دفع سريع عند التسجيل'
             });

--- a/src/pages/ClassManagementPage.tsx
+++ b/src/pages/ClassManagementPage.tsx
@@ -186,7 +186,7 @@ export default function ClassManagementPage() {
               await paymentsApi.create({
                 student_registration_id: existingRegistration.id,
                 amount: studentData.payment,
-                payment_date: format(new Date(), 'yyyy-MM-dd'),
+                payment_date: new Date().toISOString().split('T')[0],
                 payment_method: 'cash',
                 notes: `دفعة شهر ${paymentMonth}`,
               });
@@ -228,7 +228,7 @@ export default function ClassManagementPage() {
               await paymentsApi.create({
                 student_registration_id: registration.id,
                 amount: studentData.payment,
-                payment_date: format(new Date(), 'yyyy-MM-dd'),
+                payment_date: new Date().toISOString().split('T')[0],
                 payment_method: 'cash',
                 notes: `دفعة شهر ${paymentMonth}`,
               });


### PR DESCRIPTION
Fix bulk upload payment processing and group fees display.

Payments were not being created due to a missing `payment_date` field. Group fees (`total_fees`) were incorrectly set from individual student payments instead of the class's standard `class_fees` from the booking.

---
<a href="https://cursor.com/background-agent?bcId=bc-5031eda3-bfdf-465c-877e-6ba99798ebd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5031eda3-bfdf-465c-877e-6ba99798ebd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>