### PR TITLE
Investigate revenue view data limit

### DIFF
--- a/src/components/dashboard/StatsCards.tsx
+++ b/src/components/dashboard/StatsCards.tsx
@@ -58,17 +58,14 @@ export const StatsCards = ({
     queryKey: ['monthly-earnings'],
     queryFn: async () => {
       const now = new Date();
-      const startDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
-      const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999).toISOString();
+      const startDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0];
+      const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999).toISOString().split('T')[0];
 
       const { data, error } = await supabase
-        .from('payment_records')
-        .select('amount,payment_date')
-        .gte('payment_date', startDate)
-        .lte('payment_date', endDate);
+        .rpc('get_payments_sum', { start_date: startDate, end_date: endDate });
 
       if (error) throw error;
-      return (data || []).reduce((sum: number, r: { amount: number }) => sum + (r.amount || 0), 0);
+      return Number(data || 0);
     }
   });
 

--- a/src/components/receptionist/ReceptionistDashboard.tsx
+++ b/src/components/receptionist/ReceptionistDashboard.tsx
@@ -88,17 +88,14 @@ export function ReceptionistDashboard() {
     queryKey: ['monthly-earnings'],
     queryFn: async () => {
       const now = new Date();
-      const startDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
-      const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999).toISOString();
+      const startDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0];
+      const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999).toISOString().split('T')[0];
 
       const { data, error } = await supabase
-        .from('payment_records')
-        .select('amount,payment_date')
-        .gte('payment_date', startDate)
-        .lte('payment_date', endDate);
+        .rpc('get_payments_sum', { start_date: startDate, end_date: endDate });
 
       if (error) throw error;
-      return (data || []).reduce((sum: number, r: { amount: number }) => sum + (r.amount || 0), 0);
+      return Number(data || 0);
     }
   });
 

--- a/supabase/migrations/20250808110000_add_get_payments_sum_rpc.sql
+++ b/supabase/migrations/20250808110000_add_get_payments_sum_rpc.sql
@@ -1,0 +1,17 @@
+-- RPC to sum payments in a date range to avoid client-side 1000 row caps
+CREATE OR REPLACE FUNCTION public.get_payments_sum(
+  start_date DATE,
+  end_date DATE
+)
+RETURNS NUMERIC
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(SUM(amount), 0)::NUMERIC
+  FROM public.payment_records
+  WHERE payment_date >= start_date
+    AND payment_date <= end_date;
+$$;
+
+-- Allow all users who can select from payment_records to execute this function
+GRANT EXECUTE ON FUNCTION public.get_payments_sum(DATE, DATE) TO anon, authenticated, service_role;


### PR DESCRIPTION
Calculate monthly revenue server-side to avoid Supabase 1000-row fetch limit.

The previous client-side sum of `payment_records` could be capped at 1000 rows due to Supabase's default response limit, leading to an inaccurate total for "إيرادات هذا الشهر". This change introduces a new Supabase RPC function `get_payments_sum` to perform the aggregation directly on the database, ensuring the full, accurate sum is always retrieved.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fd47063-ebf4-467c-a685-bf051fc077d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fd47063-ebf4-467c-a685-bf051fc077d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

