### PR TITLE
Fix dashboard loading bug

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -10,6 +10,12 @@ export const useAuth = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    // Safety timeout to prevent infinite loading in edge cases
+    const safetyTimeout = window.setTimeout(() => {
+      console.warn("Auth loading exceeded expected time. Proceeding without full profile.");
+      setLoading(false);
+    }, 8000);
+
     // Get initial session
     const initializeAuth = async () => {
       try {
@@ -48,7 +54,10 @@ export const useAuth = () => {
       }
     );
 
-    return () => subscription.unsubscribe();
+    return () => {
+      window.clearTimeout(safetyTimeout);
+      subscription.unsubscribe();
+    };
   }, []);
 
   const fetchProfile = async (userId: string) => {


### PR DESCRIPTION
Add a safety timeout to `useAuth` to prevent the dashboard from getting stuck in a loading state.

The dashboard was observed to be stuck in a loading state (showing skeletons indefinitely) if the underlying session or profile fetching operations within `useAuth` did not complete. This change introduces an 8-second timeout to ensure the `loading` state is eventually cleared, allowing the dashboard to proceed even if the fetch hangs.

---
<a href="https://cursor.com/background-agent?bcId=bc-577fe842-f4cc-4ee4-b26d-487cacd8b544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-577fe842-f4cc-4ee4-b26d-487cacd8b544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

