### PR TITLE
Fix group management page styling

### DIFF
--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -22,6 +22,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { cn } from "@/lib/utils";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useEffect } from "react";
 
 interface AdminSidebarProps {
   children: React.ReactNode;
@@ -187,6 +188,17 @@ export function AdminSidebar({ children }: AdminSidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { profile } = useAuth();
+
+  // Lock body scroll when sidebar is open (mobile drawer)
+  useEffect(() => {
+    const body = document.body;
+    if (sidebarOpen) {
+      body.classList.add("overflow-hidden");
+    } else {
+      body.classList.remove("overflow-hidden");
+    }
+    return () => body.classList.remove("overflow-hidden");
+  }, [sidebarOpen]);
 
   const getRoleBadge = (role?: string) => {
     switch (role) {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useEffect } from "react";
 
 interface NavbarProps {
   userRole?: 'owner' | 'manager' | 'space_manager' | 'read_only';
@@ -28,6 +29,17 @@ export const Navbar = ({
   const { theme, setTheme } = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
+
+  // Lock body scroll when sidebar is open (mobile drawer)
+  useEffect(() => {
+    const body = document.body;
+    if (sidebarOpen) {
+      body.classList.add("overflow-hidden");
+    } else {
+      body.classList.remove("overflow-hidden");
+    }
+    return () => body.classList.remove("overflow-hidden");
+  }, [sidebarOpen]);
 
   const handleSignOut = async () => {
     setIsLoading(true);


### PR DESCRIPTION
Lock body scrolling when the sidebar is open to fix mobile styling issues on the "إدارة المجموعات" page.

---
<a href="https://cursor.com/background-agent?bcId=bc-20b69ec6-d1d6-4a82-b46e-2be2480fb4ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20b69ec6-d1d6-4a82-b46e-2be2480fb4ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

