### PR TITLE
Fix global class fee update propagation

### DIFF
--- a/supabase/migrations/20250809130000_add_set_booking_custom_fee.sql
+++ b/supabase/migrations/20250809130000_add_set_booking_custom_fee.sql
@@ -1,0 +1,36 @@
+-- Create RPC to set custom fee for a booking and apply it to all registrations atomically
+CREATE OR REPLACE FUNCTION public.set_booking_custom_fee(
+  p_booking_id UUID,
+  p_fee DECIMAL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Update the booking to be custom and set the new fee
+  UPDATE public.bookings
+  SET class_fees = p_fee,
+      is_custom_fee = true,
+      updated_at = now()
+  WHERE id = p_booking_id;
+
+  -- Propagate the new fee to registrations and recompute payment status
+  UPDATE public.student_registrations sr
+  SET total_fees = p_fee,
+      payment_status = CASE 
+        WHEN sr.paid_amount = 0 THEN 'pending'
+        WHEN sr.paid_amount >= p_fee THEN 'paid'
+        ELSE 'partial'
+      END,
+      updated_at = now()
+  WHERE sr.booking_id = p_booking_id;
+END;
+$$;
+
+-- Grant execution to common roles
+GRANT EXECUTE ON FUNCTION public.set_booking_custom_fee(UUID, DECIMAL) TO anon, authenticated, service_role;
+
+-- Ensure PostgREST sees the new RPC immediately
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Add an atomic database RPC and update the API to reliably apply class fee changes to all student registrations.

Previous attempts to fix the global class fee update were prone to race conditions or partial updates, leading to the user's reported persistent issues. This PR introduces a new PostgreSQL RPC that performs the class fee update and the propagation to all student registrations within a single, atomic transaction. This guarantees data consistency and immediate application of the fee change across all related records, with robust fallbacks for compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-36579d03-94ff-4849-b99e-5e8456a7385b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36579d03-94ff-4849-b99e-5e8456a7385b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

