### PR TITLE
Debug booking data fetch failure

### DIFF
--- a/src/pages/BookingsPage.tsx
+++ b/src/pages/BookingsPage.tsx
@@ -124,7 +124,7 @@ const BookingsPage = () => {
       const bookingIds = bookingsData.map((b: any) => b.id);
       const { data: countsRows, error: countsError } = await supabase
         .from('student_registrations')
-        .select('booking_id, count:count(id)')
+        .select('booking_id, count:id')
         .in('booking_id', bookingIds)
         .group('booking_id');
 


### PR DESCRIPTION
Update PostgREST aggregate syntax for booking counts to fix data loading error.

The previous `count:count(id)` syntax was causing an API error due to incorrect aggregate aliasing with PostgREST, resulting in the "data load failed" message. The corrected `count:id` with `.group('booking_id')` aligns with Supabase's expected format.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a3e2af5-a773-4f46-87e5-801fd0521693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a3e2af5-a773-4f46-87e5-801fd0521693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

