### PR TITLE
Finalize admin read access policies

### DIFF
--- a/supabase/migrations/20250813131530_finalize_admin_read_policies.sql
+++ b/supabase/migrations/20250813131530_finalize_admin_read_policies.sql
@@ -1,0 +1,33 @@
+-- This script provides a complete and idempotent set of read policies for the 'admin' role.
+
+-- Grant SELECT on 'halls'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.halls;
+CREATE POLICY "Allow read access for admins" ON public.halls FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'students'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.students;
+CREATE POLICY "Allow read access for admins" ON public.students FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'teachers'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.teachers;
+CREATE POLICY "Allow read access for admins" ON public.teachers FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'bookings'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.bookings;
+CREATE POLICY "Allow read access for admins" ON public.bookings FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'subjects'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.subjects;
+CREATE POLICY "Allow read access for admins" ON public.subjects FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'stages'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.stages;
+CREATE POLICY "Allow read access for admins" ON public.stages FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'registrations'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.registrations;
+CREATE POLICY "Allow read access for admins" ON public.registrations FOR SELECT USING (get_my_claim('user_role') = '"admin"');
+
+-- Grant SELECT on 'payments'
+DROP POLICY IF EXISTS "Allow read access for admins" ON public.payments;
+CREATE POLICY "Allow read access for admins" ON public.payments FOR SELECT USING (get_my_claim('user_role') = '"admin"');


### PR DESCRIPTION
Add Supabase migration to finalize admin read-access RLS policies, resolving the admin dashboard's infinite loading state.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4440ad8-57a6-422f-b0bb-94147abfa1a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4440ad8-57a6-422f-b0bb-94147abfa1a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

