### PR TITLE
Filter out inactive teacher profiles

### DIFF
--- a/src/api/teachers.ts
+++ b/src/api/teachers.ts
@@ -9,7 +9,8 @@ export const getTeachers = async (): Promise<Teacher[]> => {
       subjects:subject_id(name),
       teacher_academic_stages(
         academic_stages(name)
-      )
+      ),
+      profiles!inner(id)
     `)
     .order("name");
   


### PR DESCRIPTION
Filter out 'ghost' teacher profiles by ensuring they are linked to a user account.

The initial task specified filtering by `user_id`, but the database schema links teachers to user accounts via `profiles.teacher_id`. An inner join on `profiles` was used to achieve the goal of preventing unlinked teacher profiles from appearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebb39c99-2cad-43af-a0ac-16e52b2acdf9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebb39c99-2cad-43af-a0ac-16e52b2acdf9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

