### PR TITLE
Fix website caching with meta tags and hashing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="vite-env" content="VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <title>arabic-hall-booking-system</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />


### PR DESCRIPTION
Add cache-busting meta tags to `index.html` to prevent browser caching of the HTML file.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdb6062b-c692-4689-a960-7d1814e0cb25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdb6062b-c692-4689-a960-7d1814e0cb25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

